### PR TITLE
Make renderer send language change message to all windows

### DIFF
--- a/app/configs/i18next.config.client.js
+++ b/app/configs/i18next.config.client.js
@@ -1,6 +1,7 @@
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import config from './app.config';
+import settings from '../shared/settings';
 
 const i18nextOptions = {
   debug: true,
@@ -8,7 +9,7 @@ const i18nextOptions = {
     escapeValue: false
   },
   saveMissing: true,
-  lng: 'en',
+  lng: settings.getSync('PREFERRED_LANGUAGE', 'en'),
   fallbackLng: config.fallbackLng,
   whitelist: config.languages,
   react: {

--- a/app/configs/i18next.config.js
+++ b/app/configs/i18next.config.js
@@ -2,6 +2,7 @@ import i18next from 'i18next';
 import i18nextBackend from 'i18next-node-fs-backend';
 import config from './app.config';
 import path from 'path';
+import settings from '../shared/settings';
 
 const i18nextOptions = {
   backend: {
@@ -14,7 +15,7 @@ const i18nextOptions = {
     escapeValue: false
   },
   saveMissing: true,
-  lng: 'en',
+  lng: settings.getSync('PREFERRED_LANGUAGE', 'en'),
   fallbackLng: config.fallbackLng,
   whitelist: config.languages,
   react: {

--- a/app/main.js
+++ b/app/main.js
@@ -8,6 +8,7 @@ import shellEnv from 'shell-env';
 import fixPath from 'fix-path';
 import { initSentry } from './shared/sentry';
 import { promptUser } from './main/sentry-permission-prompt';
+import settings from './shared/settings';
 
 let mainWindow = null;
 const isDev = process.env.NODE_ENV === 'development';
@@ -88,8 +89,9 @@ app.on('ready', async () => {
     }]).popup(mainWindow);
   });
 
-  i18n.on('languageChanged', (languageCode) => {
+  i18n.on('languageChanged', async (languageCode) => {
     rebuildMenus();
+    await settings.set('PREFERRED_LANGUAGE', languageCode);
     webContents.getAllWebContents().forEach((wc) => {
       wc.send('appium-language-changed', {
         language: languageCode,

--- a/app/main.js
+++ b/app/main.js
@@ -1,6 +1,6 @@
 import i18n from './configs/i18next.config';
 import config from './configs/app.config';
-import { app, BrowserWindow, Menu } from 'electron';
+import { app, BrowserWindow, Menu, webContents } from 'electron';
 import { initializeIpc } from './main/appium';
 import { setSavedEnv } from './main/helpers';
 import rebuildMenus from './main/menus';
@@ -90,10 +90,12 @@ app.on('ready', async () => {
 
   i18n.on('languageChanged', (languageCode) => {
     rebuildMenus();
-    mainWindow.webContents.send('appium-language-changed', {
-      language: languageCode,
-      namespace: config.namespace,
-      resource: i18n.getResourceBundle(languageCode, config.namespace)
+    webContents.getAllWebContents().forEach((wc) => {
+      wc.send('appium-language-changed', {
+        language: languageCode,
+        namespace: config.namespace,
+        resource: i18n.getResourceBundle(languageCode, config.namespace)
+      });
     });
   });
 

--- a/app/main/appium.js
+++ b/app/main/appium.js
@@ -383,7 +383,8 @@ function connectServerErrorBackdoor () {
 
 function connectGetInitialTranslation () {
   ipcMain.on('get-initial-translations', async (event) => {
-    await i18n.loadLanguages('en');
+    const language = await settings.get('PREFERRED_LANGUAGE', 'en');
+    await i18n.loadLanguages(language);
     const initial = {
       'en': {
         'translation': i18n.getResourceBundle('en', config.namespace)


### PR DESCRIPTION
This fixed it for the ConfigPage.... the problem was that `appium-language-changed` was only being sent to the main window. This makes it send it to all windows. 

Also uses `electron-settings` so that language of choice is persisted between Appium Desktop sessions.

Other changes I'd like to make are:
* Make the I18N translations available on all containers. Preferably find a way to configure it one place so that all containers get them, and we don't have to do this for all containers:

```js
export default _.flowRight(
  withTranslation(config.namespace),
  connect(mapStateToProps, mapDispatchToProps)
)(ConfigPage);
```
